### PR TITLE
Images in articles list not showing on android emulator

### DIFF
--- a/components/ArticlesList.js
+++ b/components/ArticlesList.js
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
     width: Dimensions.get("window").width - 10,
     paddingLeft: 5,
     paddingBottom: 5,
-    borderBottomEndRadius: 7,
+    borderBottomRightRadius: 7,
     borderBottomLeftRadius: 7,
     backgroundColor: "rgba(0,0,0,0.5)",
     marginLeft: -5,
@@ -109,8 +109,7 @@ const ArticlesList = ({ navigation }) => {
               }}
             >
               <Image
-                defaultSource={RandomPictures.getPicture()}
-                source={item.image}
+                source={item.image ? { uri: item.image } : { uri:RandomPictures.getPicture() }}
                 style={styles.image}
               />
               <View style={styles.subCard}>


### PR DESCRIPTION
### This PR contains:
- Fixes images not showing on android emulator in ArticlesList.js

@Mljungho @elvitak @DefyCab 

[Pivotal Tracker Bug](https://www.pivotaltracker.com/story/show/181099140)

![Screenshot from 2022-01-31 18-40-54](https://user-images.githubusercontent.com/92155737/151846831-23ec10e2-9b4d-4eca-8c50-6c8879dde162.png)
![Screenshot from 2022-01-31 18-41-02](https://user-images.githubusercontent.com/92155737/151846844-906c6c20-3b28-4b18-a2dc-59c5d6630442.png)

